### PR TITLE
expose cli via manifest bin entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description":  "Render frames of Asciicasts as SVGs.",
 	"version":      "0.2.0",
 	"main":         "index.js",
-	"bin":          "cli.js",
+	"bin":          "./cli.js",
 	"files":        ["index.js", "colors.js", "cli.js"],
 	"keywords":     ["svg", "asciinema", "asciicast"],
 	"author":       "Jannis R <mail@jannisr.de>",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"description":  "Render frames of Asciicasts as SVGs.",
 	"version":      "0.2.0",
 	"main":         "index.js",
+	"bin":          "cli.js",
 	"files":        ["index.js", "colors.js", "cli.js"],
 	"keywords":     ["svg", "asciinema", "asciicast"],
 	"author":       "Jannis R <mail@jannisr.de>",


### PR DESCRIPTION
There is a command line interface implemented but not automatically exposed via the package's manifest. This change exposes the cli as `asciicast-to-svg`