### PR TITLE
move from deprecated virtual-dom-stringify to vdom-to-html

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const minimist = require('minimist')
-const toString = require('virtual-dom-stringify')
+const toString = require('vdom-to-html')
 
 const pkg = require('./package.json')
 const renderAt = require('.')

--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const toString = require('virtual-dom-stringify')
+const toString = require('vdom-to-html')
 const renderAt = require('.')
 
 const asciicast = require('./example.json')

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
 		"headless-terminal": "^0.4.0",
 		"minimist": "^1.2.0",
 		"screen-buffer": "^0.4.0",
-		"virtual-dom": "^2.1.1",
-		"virtual-dom-stringify": "^3.0.1"
+		"vdom-to-html": "^2.3.1",
+		"virtual-dom": "^2.1.1"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4",


### PR DESCRIPTION
Does away with deprecation warnings during install